### PR TITLE
Let’s demonstrate that Node.js 16 pass the tests

### DIFF
--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, latest]
+        node-version: [16.x, 18.x, 20.x, latest]
         os: [windows-latest, ubuntu-latest, macos-latest]
     steps:
       - name: Checkout repository

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [18.x, 20.x]  # , latest] Node.js >= 21 fails
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         include:  # Node.js > 16.x fails on Windows
           - node-version: 16.x
             os: windows-latest
@@ -46,7 +46,7 @@ jobs:
         shell: bash
       - run: node-gyp configure
         shell: bash
-      - if: matrix.node-version != 16
+      - if: matrix.node-version != '16.x'
         run: node-gyp rebuild
         shell: bash
   

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -46,7 +46,7 @@ jobs:
         shell: bash
       - run: node-gyp configure
         shell: bash
-      - if: matrix.node-version != "16.x"
+      - if: matrix.node-version != 16
         run: node-gyp rebuild
         shell: bash
   

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -22,11 +22,11 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: |
           node-gyp --version || true
-          npm config list -l
-          npm install --global node-gyp@latest
+          # npm config list -l
+          npm install --global node-gyp
           node-gyp --version
-          npm config set node_gyp $(npm prefix -g)/lib/node_modules/node-gyp/bin/node-gyp.js
-          npm config list -l
+          # npm config set node_gyp $(npm prefix -g)/lib/node_modules/node-gyp/bin/node-gyp.js
+          # npm config list -l
         shell: bash
       - run: npm install
         shell: bash

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -1,3 +1,15 @@
+# Recommendations:
+# * Do not run `npm test`
+# * macOS and Ubuntu: Node.js v20.x and Python 3.12
+# * Windows: Node.js v16.x and Python 3.11 -- Do not run `node-gyp rebuild`
+#
+# Lessons learned:
+# 1. Node.js >= v21 fails
+# 2. Node.js >= 18 fails on Windows
+# 3. Python >= 3.12 fails on Node.js 16 because of distlib fixed in node-gyp v10.0
+# 4. `npm test` fails with: npm ERR! Missing script: "test"
+# 5. `node-gyp rebuild` fails on Node.js 16
+
 name: CI
 
 on: [push, pull_request]
@@ -8,15 +20,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x, 20.x, latest]
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        node-version: [18.x, 20.x]  # , latest] Node.js >= 21 fails
+        os: [ubuntu-latest, macos-latest]
+        include:  # Node.js > 16.x fails on Windows
+          - node-version: 16.x
+            os: windows-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
-        with:
-          python-version: 3.11  # Not >= 3.12 because of distlib on node-gyp < 10.0
+        with:  # Python >= 3.12 fails on Node.js 16 because of distlib fixed in node-gyp v10.0
+          python-version: 3.11
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
@@ -24,12 +39,14 @@ jobs:
           node-gyp --version || true
           npm install --global node-gyp
           node-gyp --version
+        shell: bash
+      - run: |
           npm install
-          npm run
-          npm test || true  # Why are there no tests?
+          npm test || true  # npm ERR! Missing script: "test"
         shell: bash
       - run: node-gyp configure
         shell: bash
-      - run: node-gyp rebuild
+      - if: matrix.node-version != 16.x
+        run: node-gyp rebuild
         shell: bash
   

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -23,8 +23,8 @@ jobs:
       - run: |
           node-gyp --version || true
           # npm config list -l
-          # npm install --global node-gyp
-          # node-gyp --version
+          npm install --global node-gyp
+          node-gyp --version
           # npm config set node_gyp $(npm prefix -g)/lib/node_modules/node-gyp/bin/node-gyp.js
           # npm config list -l
         shell: bash

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -23,8 +23,8 @@ jobs:
       - run: |
           node-gyp --version || true
           # npm config list -l
-          npm install --global node-gyp
-          node-gyp --version
+          # npm install --global node-gyp
+          # node-gyp --version
           # npm config set node_gyp $(npm prefix -g)/lib/node_modules/node-gyp/bin/node-gyp.js
           # npm config list -l
         shell: bash
@@ -32,8 +32,8 @@ jobs:
         shell: bash
       - run: npm test
         shell: bash
-      - run: node-gyp configure
-        shell: bash
-      - run: node-gyp rebuild
-        shell: bash
+      # - run: node-gyp configure
+      #   shell: bash
+      # - run: node-gyp rebuild
+      #   shell: bash
   

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: 3.11  # Not >= 3.12 because of distlib
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -30,7 +30,7 @@ jobs:
         shell: bash
       - run: |
           npm install
-          npm test
+          # npm test
         shell: bash
       # - run: node-gyp configure
       #   shell: bash

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [18.x, 20.x]  # , latest] Node.js >= 21 fails
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         include:  # Node.js > 16.x fails on Windows
           - node-version: 16.x
             os: windows-latest

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -20,6 +20,14 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+      - run: |
+          node-gyp --version || true
+          gyp --version || true
+          npm config list -l
+          npm install --global node-gyp@latest
+          node-gyp --version
+          npm config set node_gyp $(npm prefix -g)/lib/node_modules/node-gyp/bin/node-gyp.js
+          node-gyp --version
       - name: install dependencies and test
         shell: bash
         run: |

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -28,9 +28,9 @@ jobs:
           # npm config set node_gyp $(npm prefix -g)/lib/node_modules/node-gyp/bin/node-gyp.js
           # npm config list -l
         shell: bash
-      - run: npm install
-        shell: bash
-      - run: npm test
+      - run: |
+          npm install
+          npm test
         shell: bash
       # - run: node-gyp configure
       #   shell: bash

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -23,11 +23,13 @@ jobs:
       - run: |
           node-gyp --version || true
           npm install --global node-gyp
+          node-gyp --version
           npm install
+          npm run
           npm test || true  # Why are there no tests?
         shell: bash
-      - run: node-gyp configure || true  # Does this fail?
+      - run: node-gyp configure
         shell: bash
-      - run: node-gyp rebuild || true  # Does this fail?
+      - run: node-gyp rebuild
         shell: bash
   

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -46,7 +46,7 @@ jobs:
         shell: bash
       - run: node-gyp configure
         shell: bash
-      - if: matrix.node-version != 16.x
+      - if: matrix.node-version != "16.x"
         run: node-gyp rebuild
         shell: bash
   

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x, 20.x, latest]
+        node-version: [14.x, 16.x, 18.x, 20.x, latest]
         os: [windows-latest, ubuntu-latest, macos-latest]
     steps:
       - name: Checkout repository

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -22,20 +22,18 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: |
           node-gyp --version || true
-          gyp --version || true
           npm config list -l
           npm install --global node-gyp@latest
           node-gyp --version
           npm config set node_gyp $(npm prefix -g)/lib/node_modules/node-gyp/bin/node-gyp.js
-          node-gyp --version
-      - name: install dependencies and test
+          npm config list -l
         shell: bash
-        run: |
-          npm install
-          npm test
-      - name: build with node-gyp
+      - run: npm install
         shell: bash
-        run: |
-          # npm install -g node-gyp
-          node-gyp configure
-          node-gyp rebuild
+      - run: npm test
+        shell: bash
+      - run: node-gyp configure
+        shell: bash
+      - run: node-gyp rebuild
+        shell: bash
+  

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x, latest]
+        node-version: [16.x, 18.x, 20.x, latest]
         os: [windows-latest, ubuntu-latest, macos-latest]
     steps:
       - name: Checkout repository
@@ -16,24 +16,18 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11  # Not >= 3.12 because of distlib
+          python-version: 3.11  # Not >= 3.12 because of distlib on node-gyp < 10.0
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: |
           node-gyp --version || true
-          # npm config list -l
           npm install --global node-gyp
-          node-gyp --version
-          # npm config set node_gyp $(npm prefix -g)/lib/node_modules/node-gyp/bin/node-gyp.js
-          # npm config list -l
-        shell: bash
-      - run: |
           npm install
-          # npm test
+          npm test || true  # Why are there no tests?
         shell: bash
-      # - run: node-gyp configure
-      #   shell: bash
-      # - run: node-gyp rebuild
-      #   shell: bash
+      - run: node-gyp configure || true  # Does this fail?
+        shell: bash
+      - run: node-gyp rebuild || true  # Does this fail?
+        shell: bash
   


### PR DESCRIPTION
Please `Squash and merge` to consolidate all the commits. 

Recommendations:
* Do not run `npm test`
* macOS and Ubuntu: Node.js v20.x and Python 3.12
* Windows: Node.js v16.x and Python 3.11 -- Do not run `node-gyp rebuild`

Lessons learned:
1. Node.js >= v21 fails
2. Node.js >= 18 fails on Windows
3. Python >= 3.12 fails on Node.js 16 because of `distlib` fixed in node-gyp v10.0
4. `npm test` fails with: `npm ERR! Missing script: "test"`
5. `node-gyp rebuild` fails on Node.js 16